### PR TITLE
Stagger spawns in Wave Spawner to avoid hitch

### DIFF
--- a/addons/ai/XEH_preInit.sqf
+++ b/addons/ai/XEH_preInit.sqf
@@ -1,3 +1,5 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+#include "initSettings.sqf"

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -38,25 +38,36 @@ _data params ['_groups', '_vehicles', '_objects'];
 
 {
     _x params ['_type','_pos','_vectorDirAndUp','_custom', '_pylons'];
-    private _formationType = "NONE";
-    if((_pos select 2) > 3) then {_formationType = "FLY"};
-    private _vehicle = createVehicle [_type, [0,0,0], [], 0, _formationType];
-    _vehicle setPosATL _pos;
-    _vehicle setVectorDirAndUp _vectorDirAndUp;
-    [_vehicle,_custom select 0,_custom select 1] spawn BIS_fnc_initVehicle;
 
-    if(count _pylons > 0) then {
-        private _pylonPaths = (configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
+    [
         {
-            _vehicle removeWeaponGlobal getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon")
-        } forEach getPylonMagazines _vehicle;
-        {
-            _vehicle setPylonLoadout [_forEachIndex + 1, _x, true, _pylonPaths select _forEachIndex]
-        } forEach _pylons;
-    };
-    _spawnedVehicles pushBack _vehicle;
+            _this params ['_type','_pos','_vectorDirAndUp','_custom', '_pylons', '_spawnedVehicles'];
+            private _formationType = "NONE";
+            if((_pos select 2) > 3) then {_formationType = "FLY"};
+            private _vehicle = createVehicle [_type, [0,0,0], [], 0, _formationType];
+            _vehicle setPosATL _pos;
+            _vehicle setVectorDirAndUp _vectorDirAndUp;
+            [_vehicle,_custom select 0,_custom select 1] spawn BIS_fnc_initVehicle;
+
+            if(count _pylons > 0) then {
+                private _pylonPaths = (configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"]) apply {getArray (_x >> "turret")};
+                {
+                    _vehicle removeWeaponGlobal getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon")
+                } forEach getPylonMagazines _vehicle;
+                {
+                    _vehicle setPylonLoadout [_forEachIndex + 1, _x, true, _pylonPaths select _forEachIndex]
+                } forEach _pylons;
+            };
+            _spawnedVehicles pushBack _vehicle;
+            missionNamespace setVariable ["hola", 123, true];
+        },
+        [_type, _pos, _vectorDirAndUp, _custom, _pylons, _spawnedVehicles],
+        (_forEachIndex)*GVAR(wavespawnStaggerSize)
+    ] call CBA_fnc_execAfterNFrames;
 
 } forEach _vehicles;
+
+private _vehicleDelay = (count _vehicles)*GVAR(wavespawnStaggerSize); // Groups have to be spawned after all vehicles to avoid race conditions
 
 {
     _x params ['_side', '_units', '_waypoints'];
@@ -120,12 +131,12 @@ _data params ['_groups', '_vehicles', '_objects'];
             _spawnedGroups pushBack _grp;
         },
         [_side, _units, _waypoints, _spawnedVehicles, _spawnedUnits, _spawnedGroups],
-        (_forEachIndex+1)*GVAR(wavespawnStaggerSize)
+        _vehicleDelay + (_forEachIndex)*GVAR(wavespawnStaggerSize)
     ] call CBA_fnc_execAfterNFrames;
 
 } forEach _groups;
 
-private _totalDelay = (count _groups)*GVAR(wavespawnStaggerSize);
+private _totalDelay = _vehicleDelay + (count _groups)*GVAR(wavespawnStaggerSize);
 
 [
     {

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -61,98 +61,115 @@ _data params ['_groups', '_vehicles', '_objects'];
 {
     _x params ['_side', '_units', '_waypoints'];
 
-    private _grp = createGroup [_side, true]; // Delete group when empty
-    {
-        _x params ["_type","_pos","_vectorDirAndUp","_gear", "_vehicleIndex", "_vehicleRole", "_unused", "_assignGearFaction", "_assignGearRole"];
-        private _unit = _grp createUnit [_type, [0,0,0],[] , 0, "NONE"];
-        _spawnedUnits pushBack _unit;
-        _unit setPosATL _pos;
-        _unit setUnitLoadout [_gear, false];
-        _unit setVectorDirAndUp _vectorDirAndUp;
-        if (_vehicleIndex >= 0) then {
-            private _vehicle = _spawnedVehicles # _vehicleIndex;
-            _vehicleRole params ["_role", "_path"];
-            _role = toLower _role;
-            switch(_role) do {
-                case 'driver': {
-                    _unit assignAsDriver _vehicle;
-                    _unit moveInDriver _vehicle;
-                };
-                case 'cargo': {
-                    if(isNil '_path') then {
-                        _unit assignAsCargo _vehicle;
-                        _unit moveInCargo _vehicle;
-                    } else {
-                        if(_path isEqualType []) then {
-                            _unit assignAsTurret [_vehicle, _path];
-                            _unit moveInTurret [_vehicle, _path];
-                        } else {
-                            _unit assignAsCargoIndex [_vehicle, _path];
-                            _unit moveInCargo [_vehicle, _path];
-                        }
-                    }
-                };
-                case 'turret': {
-                    _unit assignAsTurret [_vehicle, _path];
-                    _unit moveInTurret [_vehicle, _path];
-                };
-            };
-        };
-
-        if (!isNil "_assignGearFaction" && !isNil "_assignGearRole") then {
-            [_unit, _assignGearFaction] call EFUNC(assignGear,setFaction);
-            [_unit, _assignGearRole] call EFUNC(assignGear,setRole);
-            [_unit] call EFUNC(assignGear,assignGear);
-        };
-    } forEach _units;
-    (units _grp) join _grp;
-     _lastIndex = (count waypoints _grp)-1;
-    [_grp] call CBA_fnc_clearWaypoints;
-    {
-        [_grp, _forEachIndex + 1, _x] call CFUNC(deserializeWaypoint);
-    } forEach _waypoints;
-    if((count waypoints _grp) > 1) then {
-        _grp setCurrentWaypoint [_grp,1]; // skip the next one okeyyo..
-    };
-    _spawnedGroups pushBack _grp;
-} forEach _groups;
-
-_wave = _logic getVariable ["Waves",1];
-_logic setVariable ["Waves", (_wave-1), true];
-_handlers = _logic getVariable ["Handlers",[]];
-{
-    if(_x isEqualType {}) then {
-        [_wave,_spawnedGroups,_spawnedUnits,_spawnedVehicles,_spawnedObjects,_logic,_forEachIndex] call _x;
-    };
-} forEach _handlers;
-// Check if there is another wave
-if(_logic getVariable ["Waves",1] > 0) then {
-    private _time = _logic getvariable ["Time",10];
-    private _whenDead = _logic getVariable ["WhenDead",0];
-
-    // Wait for conditions before spawning waves
     [
         {
-            //params ["","","_minimumDead","_spawnedUnits", "_targetTime"];
-            CBA_missionTime > (_this # 4) &&
-            {{!alive _x || lifeState _x isEqualTo "INCAPACITATED"} count (_this # 3) >= (_this # 2)}
-        },
-        FUNC(spawnWave),
-        [_logic,_spawnedGroups,_whenDead * count _spawnedUnits,_spawnedUnits, CBA_missionTime + _time]
-    ] call CBA_fnc_waitUntilAndExecute;
+            _this params ['_side', '_units', '_waypoints', '_spawnedVehicles', '_spawnedUnits', '_spawnedGroups'];
+            private _grp = createGroup [_side, true]; // Delete group when empty
+            {
+                _x params ["_type","_pos","_vectorDirAndUp","_gear", "_vehicleIndex", "_vehicleRole", "_unused", "_assignGearFaction", "_assignGearRole"];
+                private _unit = _grp createUnit [_type, [0,0,0],[] , 0, "NONE"];
+                _spawnedUnits pushBack _unit;
+                _unit setPosATL _pos;
+                _unit setUnitLoadout [_gear, false];
+                _unit setVectorDirAndUp _vectorDirAndUp;
+                if (_vehicleIndex >= 0) then {
+                    private _vehicle = _spawnedVehicles # _vehicleIndex;
+                    _vehicleRole params ["_role", "_path"];
+                    _role = toLower _role;
+                    switch(_role) do {
+                        case 'driver': {
+                            _unit assignAsDriver _vehicle;
+                            _unit moveInDriver _vehicle;
+                        };
+                        case 'cargo': {
+                            if(isNil '_path') then {
+                                _unit assignAsCargo _vehicle;
+                                _unit moveInCargo _vehicle;
+                            } else {
+                                if(_path isEqualType []) then {
+                                    _unit assignAsTurret [_vehicle, _path];
+                                    _unit moveInTurret [_vehicle, _path];
+                                } else {
+                                    _unit assignAsCargoIndex [_vehicle, _path];
+                                    _unit moveInCargo [_vehicle, _path];
+                                }
+                            }
+                        };
+                        case 'turret': {
+                            _unit assignAsTurret [_vehicle, _path];
+                            _unit moveInTurret [_vehicle, _path];
+                        };
+                    };
+                };
 
-} else {
-    deleteVehicle _logic;
-};
+                if (!isNil "_assignGearFaction" && !isNil "_assignGearRole") then {
+                    [_unit, _assignGearFaction] call EFUNC(assignGear,setFaction);
+                    [_unit, _assignGearRole] call EFUNC(assignGear,setRole);
+                    [_unit] call EFUNC(assignGear,assignGear);
+                };
+            } forEach _units;
+            (units _grp) join _grp;
+            _lastIndex = (count waypoints _grp)-1;
+            [_grp] call CBA_fnc_clearWaypoints;
+            {
+                [_grp, _forEachIndex + 1, _x] call CFUNC(deserializeWaypoint);
+            } forEach _waypoints;
+            if((count waypoints _grp) > 1) then {
+                _grp setCurrentWaypoint [_grp,1]; // skip the next one okeyyo..
+            };
+            _spawnedGroups pushBack _grp;
+        },
+        [_side, _units, _waypoints, _spawnedVehicles, _spawnedUnits, _spawnedGroups],
+        (_forEachIndex+1)*GVAR(wavespawnStaggerSize)
+    ] call CBA_fnc_execAfterNFrames;
+
+} forEach _groups;
+
+private _totalDelay = (count _groups)*GVAR(wavespawnStaggerSize);
 
 [
-    format [
-        "Spawned wave, unit count: %1, vehicle count: %2, group count %3, object count %4",
-        count _spawnedUnits,
-        count _spawnedVehicles,
-        count _spawnedGroups,
-        count _spawnedObjects
-    ],
-    count _spawnedUnits > 40,
-    "AI"
-] call EFUNC(adminmenu,log);
+    {
+        _this params ["_logic", "_spawnedGroups", "_spawnedUnits", "_spawnedVehicles", "_spawnedObjects"];
+        _wave = _logic getVariable ["Waves",1];
+        _logic setVariable ["Waves", (_wave-1), true];
+        _handlers = _logic getVariable ["Handlers",[]];
+        {
+            if(_x isEqualType {}) then {
+                [_wave,_spawnedGroups,_spawnedUnits,_spawnedVehicles,_spawnedObjects,_logic,_forEachIndex] call _x;
+            };
+        } forEach _handlers;
+        // Check if there is another wave
+        if(_logic getVariable ["Waves",1] > 0) then {
+            private _time = _logic getvariable ["Time",10];
+            private _whenDead = _logic getVariable ["WhenDead",0];
+
+            // Wait for conditions before spawning waves
+            [
+                {
+                    //params ["","","_minimumDead","_spawnedUnits", "_targetTime"];
+                    CBA_missionTime > (_this # 4) &&
+                    {{!alive _x || lifeState _x isEqualTo "INCAPACITATED"} count (_this # 3) >= (_this # 2)}
+                },
+                FUNC(spawnWave),
+                [_logic,_spawnedGroups,_whenDead * count _spawnedUnits,_spawnedUnits, CBA_missionTime + _time]
+            ] call CBA_fnc_waitUntilAndExecute;
+
+        } else {
+            deleteVehicle _logic;
+        };
+
+        [
+            format [
+                "Spawned wave, unit count: %1, vehicle count: %2, group count %3, object count %4",
+                count _spawnedUnits,
+                count _spawnedVehicles,
+                count _spawnedGroups,
+                count _spawnedObjects
+            ],
+            count _spawnedUnits > 40,
+            "AI"
+        ] call EFUNC(adminmenu,log);
+    },
+    [_logic,_spawnedGroups,_spawnedUnits,_spawnedVehicles,_spawnedObjects],
+    _totalDelay
+] call CBA_fnc_execAfterNFrames;

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -18,6 +18,10 @@ private _spawnedGroups = [];
 private _spawnedUnits = [];
 private _spawnedObjects = [];
 private _data = _logic getVariable [QGVAR(waveData), []];
+
+private _disableStagger = _logic getVariable ["DisableStagger", false];
+private _staggerDelay = if (_disableStagger) then {0} else {GVAR(wavespawnStaggerSize)};
+
 _data params ['_groups', '_vehicles', '_objects'];
 {
     _x params ["_type", "_pos", "_dir", "_vectorDirAndUp", "_isSimple", "_simulationEnabled","_simpleObjData"];
@@ -62,12 +66,12 @@ _data params ['_groups', '_vehicles', '_objects'];
             missionNamespace setVariable ["hola", 123, true];
         },
         [_type, _pos, _vectorDirAndUp, _custom, _pylons, _spawnedVehicles],
-        (_forEachIndex)*GVAR(wavespawnStaggerSize)
+        (_forEachIndex)*_staggerDelay
     ] call CBA_fnc_execAfterNFrames;
 
 } forEach _vehicles;
 
-private _vehicleDelay = (count _vehicles)*GVAR(wavespawnStaggerSize); // Groups have to be spawned after all vehicles to avoid race conditions
+private _vehicleDelay = (count _vehicles)*_staggerDelay; // Groups have to be spawned after all vehicles to avoid race conditions
 
 {
     _x params ['_side', '_units', '_waypoints'];
@@ -131,12 +135,12 @@ private _vehicleDelay = (count _vehicles)*GVAR(wavespawnStaggerSize); // Groups 
             _spawnedGroups pushBack _grp;
         },
         [_side, _units, _waypoints, _spawnedVehicles, _spawnedUnits, _spawnedGroups],
-        _vehicleDelay + (_forEachIndex)*GVAR(wavespawnStaggerSize)
+        _vehicleDelay + (_forEachIndex)*_staggerDelay
     ] call CBA_fnc_execAfterNFrames;
 
 } forEach _groups;
 
-private _totalDelay = _vehicleDelay + (count _groups)*GVAR(wavespawnStaggerSize);
+private _totalDelay = _vehicleDelay + (count _groups)*_staggerDelay;
 
 [
     {

--- a/addons/ai/initSettings.sqf
+++ b/addons/ai/initSettings.sqf
@@ -1,0 +1,14 @@
+#include "\x\tmf\addons\ai\script_component.hpp"
+[
+    QGVAR(wavespawnStaggerSize),
+    "SLIDER",
+    ["Wave Spawn Stagger Size", "Number of frames to stagger group and vehicle spawns. 0 is original behavior."],
+    ["TMF", "Wave Spawner"],
+    [
+        0,  // Min
+        5,// Max
+        0,  // Default
+        -1   // Trailing decimals
+    ],
+    1 // isGlobal
+] call CBA_fnc_addSetting;

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -62,6 +62,12 @@ class GVAR(wavespawn) : Module_F {
             defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic"",""_wavehandlerID""];'";
             control = "EditCodeMulti5";
         };
+        class DisableStagger: Checkbox {
+            property = QGVAR(wavespawn_DisableStagger);
+            displayName = "Disable staggered spawning";
+            tooltip = "Force everything to be spawned and initialized instantaneously";
+            typeName = "BOOL";
+        };
         class ModuleDescription: ModuleDescription {};
     };
     class ModuleDescription: ModuleDescription {


### PR DESCRIPTION
~~TODO:~~ Add option to Wave Spawner module to disable stagger/override delay for specific spawners. An example use case is when you have AI path-disabled in a very specific position. With the stagger, the AI will be created and some time may pass before it is path-disabled, so it may move out of position first.